### PR TITLE
Fix #4: Add Spec2 Stats inspector presentation

### DIFF
--- a/src/Containers-OrderedSet/CTDuplicateException.class.st
+++ b/src/Containers-OrderedSet/CTDuplicateException.class.st
@@ -1,5 +1,6 @@
 Class {
-	#name : #CTDuplicateException,
-	#superclass : #Error,
-	#category : #'Containers-OrderedSet'
+	#name : 'CTDuplicateException',
+	#superclass : 'Error',
+	#category : 'Containers-OrderedSet',
+	#package : 'Containers-OrderedSet'
 }

--- a/src/Containers-OrderedSet/CTOrderedSet.class.st
+++ b/src/Containers-OrderedSet/CTOrderedSet.class.st
@@ -80,14 +80,9 @@ CTOrderedSet >> difference: aCollection [
 	^ self reject: [ :each | aCollection includes: each ]
 ]
 
-{ #category : 'initialization' }
-CTOrderedSet >> initialize [
-	super initialize.
-]
-
 { #category : 'inspecting' }
 CTOrderedSet >> inspectionStats: aBuilder [
-	<inspectorPresentationOrder: -1 title: 'Stats'> 
+	<inspectorPresentationOrder: 0 title: 'Stats'> 
 	
 	^ aBuilder newTable
 		addColumn: (SpStringTableColumn title: 'Metric' evaluated: #key);

--- a/src/Containers-OrderedSet/CTOrderedSet.class.st
+++ b/src/Containers-OrderedSet/CTOrderedSet.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : 'CTOrderedSet',
 	#superclass : 'OrderedCollection',
-	#instVars : [
-		'duplicatesSkipped'
-	],
 	#category : 'Containers-OrderedSet',
 	#package : 'Containers-OrderedSet'
 }
@@ -30,8 +27,6 @@ CTOrderedSet >> addLast: newObject [
 	(self includes: newObject)
 		ifFalse: [ ^ super addLast: newObject].
 	
-	"If we reach this line, it was a duplicate!"
-	duplicatesSkipped := duplicatesSkipped + 1.
 	^ newObject
 ]
 
@@ -88,7 +83,6 @@ CTOrderedSet >> difference: aCollection [
 { #category : 'initialization' }
 CTOrderedSet >> initialize [
 	super initialize.
-	duplicatesSkipped := 0.
 ]
 
 { #category : 'inspecting' }
@@ -100,7 +94,6 @@ CTOrderedSet >> inspectionStats: aBuilder [
 		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value asString ]);
 		items: { 
 			'Size (Unique Elements)' -> self size.
-			'Duplicates Skipped' -> duplicatesSkipped.
 			'Internal Capacity' -> self capacity.
 		};
 		yourself

--- a/src/Containers-OrderedSet/CTOrderedSet.class.st
+++ b/src/Containers-OrderedSet/CTOrderedSet.class.st
@@ -1,16 +1,20 @@
 Class {
-	#name : #CTOrderedSet,
-	#superclass : #OrderedCollection,
-	#category : #'Containers-OrderedSet'
+	#name : 'CTOrderedSet',
+	#superclass : 'OrderedCollection',
+	#instVars : [
+		'duplicatesSkipped'
+	],
+	#category : 'Containers-OrderedSet',
+	#package : 'Containers-OrderedSet'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 CTOrderedSet class >> new: aNumber [ 
 	"SequenceableCollection >> new: and new don't call initialize. So we fix it here"
 	^ (super new: aNumber) initialize
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CTOrderedSet >> addFirst: newObject [
 	"Add newObject to the beginning of the receiver unless the receiver already includes newObject. Answer newObject"	
 
@@ -19,23 +23,26 @@ CTOrderedSet >> addFirst: newObject [
 	^ newObject
 ]
 
-{ #category : #adding }
+{ #category : 'adding' }
 CTOrderedSet >> addLast: newObject [
 	"Add newObject to the end of the receiver unless the receiver already includes newObject. Answer newObject"	
 
 	(self includes: newObject)
 		ifFalse: [ ^ super addLast: newObject].
+	
+	"If we reach this line, it was a duplicate!"
+	duplicatesSkipped := duplicatesSkipped + 1.
 	^ newObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 CTOrderedSet >> allLargestSubsets [
 	"Generate all subsets of size k-1 where k is the size of receiver"
 	
 	^ self reversed collect: [ :each | self copyWithout: each ].
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 CTOrderedSet >> allSubsets [
 	"Generate all possible subsets of the receiver, excluding the receiver itself and the empty set.
 	Uses a bitmask approach for efficiency.
@@ -55,7 +62,7 @@ CTOrderedSet >> allSubsets [
 	^ subsets asArray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CTOrderedSet >> at: anInteger put: anObject [
 	"Put anObject at element index anInteger. Raise an exception if the object is already included"
 	
@@ -68,7 +75,7 @@ CTOrderedSet >> at: anInteger put: anObject [
 	CTDuplicateException signal: 'Can not insert duplicate into a set'.
 ]
 
-{ #category : #enumerating }
+{ #category : 'enumerating' }
 CTOrderedSet >> difference: aCollection [
 	"A set of all elements that appear in this set but not in aCollection. The order is the same as in first set.
 	
@@ -78,7 +85,28 @@ CTOrderedSet >> difference: aCollection [
 	^ self reject: [ :each | aCollection includes: each ]
 ]
 
-{ #category : #accessing }
+{ #category : 'initialization' }
+CTOrderedSet >> initialize [
+	super initialize.
+	duplicatesSkipped := 0.
+]
+
+{ #category : 'inspecting' }
+CTOrderedSet >> inspectionStats: aBuilder [
+	<inspectorPresentationOrder: -1 title: 'Stats'> 
+	
+	^ aBuilder newTable
+		addColumn: (SpStringTableColumn title: 'Metric' evaluated: #key);
+		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value asString ]);
+		items: { 
+			'Size (Unique Elements)' -> self size.
+			'Duplicates Skipped' -> duplicatesSkipped.
+			'Internal Capacity' -> self capacity.
+		};
+		yourself
+]
+
+{ #category : 'accessing' }
 CTOrderedSet >> intersection: aCollection [
 	"Intersection of two sets. The order is defined as follows:
 	- all elements of the first that appear in the second set
@@ -89,21 +117,21 @@ CTOrderedSet >> intersection: aCollection [
 	^ self select: [ :each | aCollection includes: each ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTOrderedSet >> isSubsetOf: aCollection [
 	"Answer true if aCollection includes all elements of the receiver"
 	
 	^ aCollection includesAll: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 CTOrderedSet >> isSupersetOf: aCollection [
 	"Answer true if receiver includes all elements of aCollection"
 	
 	^ self includesAll: aCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 CTOrderedSet >> union: aCollection [
 	"Union of two sets. The order is defined as follows:
 	- all elements of the first set go first

--- a/src/Containers-OrderedSet/Collection.extension.st
+++ b/src/Containers-OrderedSet/Collection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Collection }
+Extension { #name : 'Collection' }
 
-{ #category : #'*Containers-OrderedSet' }
+{ #category : '*Containers-OrderedSet' }
 Collection >> asOrderedSet [
 	^ CTOrderedSet withAll: self
 ]

--- a/src/Containers-OrderedSet/package.st
+++ b/src/Containers-OrderedSet/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Containers-OrderedSet' }
+Package { #name : 'Containers-OrderedSet' }


### PR DESCRIPTION
Closes #4

### Description
This PR implements a custom Spec2 Inspector presentation to display the ordered elements and adds internal tracking for skipped duplicates, as requested in Issue #4.

### Changes Made
* Added a `duplicatesSkipped` instance variable to track ignored elements.
* Updated `addLast:` to maintain the duplicate count when an item is rejected.
* Implemented `inspectionStats:` to provide a custom Spec2 Table dashboard displaying Unique Size, Internal Capacity, and Duplicates Skipped.

### Note on File Changes
I am developing on **Pharo 13**. This commit includes the automatic Tonel format upgrade (removing the `#` from metadata strings) that Pharo 13 natively applies to older Tonel repositories.

<img width="1915" height="314" alt="image" src="https://github.com/user-attachments/assets/8068c956-645e-45c0-9e1b-d0f345579014" />

<img width="1915" height="314" alt="image" src="https://github.com/user-attachments/assets/78d4b592-c29f-40b1-a1f4-83c7f433ccbd" />
