### PR TITLE
Refactor CTOrderedSet to use composition instead of OrderedCollection inheritance

### DIFF
--- a/src/Containers-OrderedSet/CTOrderedSet.class.st
+++ b/src/Containers-OrderedSet/CTOrderedSet.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'CTOrderedSet',
-	#superclass : 'OrderedCollection',
+	#superclass : 'Collection',
+	#instVars : [
+		'items'
+	],
 	#category : 'Containers-OrderedSet',
 	#package : 'Containers-OrderedSet'
 }
@@ -8,7 +11,34 @@ Class {
 { #category : 'instance creation' }
 CTOrderedSet class >> new: aNumber [ 
 	"SequenceableCollection >> new: and new don't call initialize. So we fix it here"
-	^ (super new: aNumber) initialize
+	
+	^ (super new) initialize
+]
+
+{ #category : 'initialization' }
+CTOrderedSet >> initialize [
+	super initialize.
+	items := OrderedCollection new.
+]
+
+{ #category : 'adding' }
+CTOrderedSet >> add: anObject [
+	"Add anObject unless already present"
+	
+	(self includes: anObject)
+		ifFalse: [ items add: anObject ].
+	
+	^ anObject
+]
+
+{ #category : 'adding' }
+CTOrderedSet >> addAll: aCollection [
+	"Add all elements from aCollection"
+	
+	aCollection do: [ :each |
+		self add: each ].
+	
+	^ self
 ]
 
 { #category : 'adding' }
@@ -16,7 +46,8 @@ CTOrderedSet >> addFirst: newObject [
 	"Add newObject to the beginning of the receiver unless the receiver already includes newObject. Answer newObject"	
 
 	(self includes: newObject)
-		ifFalse: [ ^ super addFirst: newObject].
+		ifFalse: [ items addFirst: newObject ].
+		
 	^ newObject
 ]
 
@@ -25,7 +56,7 @@ CTOrderedSet >> addLast: newObject [
 	"Add newObject to the end of the receiver unless the receiver already includes newObject. Answer newObject"	
 
 	(self includes: newObject)
-		ifFalse: [ ^ super addLast: newObject].
+		ifFalse: [ items addLast: newObject ].
 	
 	^ newObject
 ]
@@ -50,11 +81,24 @@ CTOrderedSet >> allSubsets [
 	1 to: (1 bitShift: size) - 2 do: [ :mask |
 		| subset |
 		subset := self species new.
+		
 		1 to: size do: [ :index |
-			(mask bitAt: index) = 1 ifTrue: [ subset addLast: (self at: index) ] ].
-		subsets add: subset ].
+			(mask bitAt: index) = 1 ifTrue: [
+				subset addLast: (self at: index)
+			]
+		].
+		
+		subsets add: subset
+	].
 	
 	^ subsets asArray
+]
+
+{ #category : 'accessing' }
+CTOrderedSet >> at: anInteger [
+	"Answer the element at anInteger"
+	
+	^ items at: anInteger
 ]
 
 { #category : 'accessing' }
@@ -65,9 +109,37 @@ CTOrderedSet >> at: anInteger put: anObject [
 		ifTrue: [ ^ anObject ].
 
 	(self includes: anObject)
-		ifFalse: [ ^ super at: anInteger put: anObject].
+		ifTrue: [
+			CTDuplicateException signal: 'Can not insert duplicate into a set'
+		].
 	
-	CTDuplicateException signal: 'Can not insert duplicate into a set'.
+	items at: anInteger put: anObject.
+	
+	^ anObject
+]
+
+{ #category : 'copying' }
+CTOrderedSet >> copy [
+	"Answer a copy of the receiver"
+	
+	| newSet |
+	newSet := self class new.
+	
+	items do: [ :each |
+		newSet add: each ].
+	
+	^ newSet
+]
+
+{ #category : 'copying' }
+CTOrderedSet >> copyWithout: anObject [
+	"Answer a copy of the receiver without anObject"
+	
+	| newSet |
+	newSet := self copy.
+	newSet remove: anObject.
+	
+	^ newSet
 ]
 
 { #category : 'enumerating' }
@@ -80,6 +152,20 @@ CTOrderedSet >> difference: aCollection [
 	^ self reject: [ :each | aCollection includes: each ]
 ]
 
+{ #category : 'enumerating' }
+CTOrderedSet >> do: aBlock [
+	"Evaluate aBlock for each element of the receiver"
+	
+	items do: aBlock
+]
+
+{ #category : 'testing' }
+CTOrderedSet >> includes: anObject [
+	"Answer whether anObject is included"
+	
+	^ items includes: anObject
+]
+
 { #category : 'inspecting' }
 CTOrderedSet >> inspectionStats: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Stats'> 
@@ -89,7 +175,7 @@ CTOrderedSet >> inspectionStats: aBuilder [
 		addColumn: (SpStringTableColumn title: 'Value' evaluated: [ :assoc | assoc value asString ]);
 		items: { 
 			'Size (Unique Elements)' -> self size.
-			'Internal Capacity' -> self capacity.
+			'Internal Capacity' -> items capacity.
 		};
 		yourself
 ]
@@ -106,6 +192,13 @@ CTOrderedSet >> intersection: aCollection [
 ]
 
 { #category : 'testing' }
+CTOrderedSet >> isEmpty [
+	"Answer true if the receiver contains no elements"
+	
+	^ items isEmpty
+]
+
+{ #category : 'testing' }
 CTOrderedSet >> isSubsetOf: aCollection [
 	"Answer true if aCollection includes all elements of the receiver"
 	
@@ -119,6 +212,76 @@ CTOrderedSet >> isSupersetOf: aCollection [
 	^ self includesAll: aCollection
 ]
 
+{ #category : 'removing' }
+CTOrderedSet >> remove: anObject [
+	"Remove anObject from the receiver"
+	
+	items remove: anObject ifAbsent: [ ].
+	
+	^ anObject
+]
+
+{ #category : 'enumerating' }
+CTOrderedSet >> reject: aBlock [
+	"Answer all elements for which aBlock evaluates to false"
+	
+	| result |
+	result := self species new.
+	
+	self do: [ :each |
+		(aBlock value: each)
+			ifFalse: [ result add: each ]
+	].
+	
+	^ result
+]
+
+{ #category : 'enumerating' }
+CTOrderedSet >> reversed [
+	"Answer the reversed order of the receiver"
+	
+	^ items reversed
+]
+
+{ #category : 'enumerating' }
+CTOrderedSet >> select: aBlock [
+	"Answer all elements for which aBlock evaluates to true"
+	
+	| result |
+	result := self species new.
+	
+	self do: [ :each |
+		(aBlock value: each)
+			ifTrue: [ result add: each ]
+	].
+	
+	^ result
+]
+
+{ #category : 'accessing' }
+CTOrderedSet >> size [
+	"Answer the number of elements in the receiver"
+	
+	^ items size
+]
+
+{ #category : 'accessing' }
+CTOrderedSet >> species [
+	"Answer the species of the receiver"
+	
+	^ CTOrderedSet
+]
+
+{ #category : 'accessing' }
+CTOrderedSet >> swap: oneIndex with: anotherIndex [
+
+	| element |
+	element := self at: oneIndex.
+	
+	items at: oneIndex put: (self at: anotherIndex).
+	items at: anotherIndex put: element
+]
+
 { #category : 'accessing' }
 CTOrderedSet >> union: aCollection [
 	"Union of two sets. The order is defined as follows:
@@ -128,5 +291,9 @@ CTOrderedSet >> union: aCollection [
 	Example:
 	{a, c, d} union: {a, b, e} = {a, c, d, b, e}"
 	
-	self addAll: aCollection
+	| result |
+	result := self copy.
+	result addAll: aCollection.
+	
+	^ result
 ]


### PR DESCRIPTION
Fixes #9

This PR removes the inheritance relationship between CTOrderedSet and OrderedCollection.

Changes made:
- Changed superclass from OrderedCollection to Collection
- Added internal OrderedCollection storage via items
- Delegated collection behavior to internal storage
- Preserved existing API and documentation comments
- Kept ordered-set uniqueness behavior intact

This avoids exposing APIs from OrderedCollection that do not semantically apply to an ordered set.